### PR TITLE
Improve response queue handling

### DIFF
--- a/worker-document-interface/src/main/java/com/hpe/caf/worker/document/model/Response.java
+++ b/worker-document-interface/src/main/java/com/hpe/caf/worker/document/model/Response.java
@@ -25,33 +25,30 @@ import javax.annotation.Nonnull;
 public interface Response extends DocumentWorkerObject
 {
     /**
-     * Returns the queue name set by {@link #setQueueNameOverride setQueueNameOverride()}, or {@code null} if
-     * {@code setQueueNameOverride()} has not been used.
-     * <p>
-     * If {@code null} is returned then the default queue set in the configuration is used.
-     *
-     * @return the queue name set on this {@code Response} object
-     */
-    String getQueueNameOverride();
-
-    /**
-     * Sets the name of the queue where the worker should send the response to this document processing task. This queue will override the
-     * default queue name specified in the configuration. It is used even if the document contains failures.
-     * <p>
-     * Passing {@code null} to this method revokes any queue name override previously set and means that the response queue selection will
-     * once again be based on the configuration.
-     *
-     * @param queueName the queue where the response message should be sent
-     */
-    void setQueueNameOverride(String queueName);
-
-    /**
      * Returns an object which can be used to manipulate the custom data that will be sent as a part of the response.
      *
      * @return the object that can be used to access or update the custom data in the response
      */
     @Nonnull
     ResponseCustomData getCustomData();
+
+    /**
+     * Returns the queue that the response will be published to if any failures are newly added to the document or to any of its
+     * subdocuments. Failures can be added to a document using the {@link Document#addFailure Document.addFailure()} method or one of the
+     * {@link Failures#add Failures.add()} methods.
+     *
+     * @return the queue that will be used if the response contains failures
+     */
+    @Nonnull
+    ResponseQueue getFailureQueue();
+
+    /**
+     * Returns the queue that the response will be published to if it does not contain any new failures.
+     *
+     * @return the queue that will be used if the response is successful
+     */
+    @Nonnull
+    ResponseQueue getSuccessQueue();
 
     /**
      * Returns the task that this response customization object is associated with.

--- a/worker-document-interface/src/main/java/com/hpe/caf/worker/document/model/ResponseQueue.java
+++ b/worker-document-interface/src/main/java/com/hpe/caf/worker/document/model/ResponseQueue.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015-2017 EntIT Software LLC, a Micro Focus company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.worker.document.model;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Used for managing the queue that response messages are published to.
+ * <p>
+ * The queue may or may not be enabled. If the queue is not enabled then response messages published to it will be discarded.
+ */
+public interface ResponseQueue extends DocumentWorkerObject
+{
+    /**
+     * Disables the response queue. This causes response messages that would otherwise have been published to the queue to be discarded.
+     */
+    void disable();
+
+    /**
+     * Returns the name of the response queue. The {@link #isEnabled()} call should be used before calling this method as it is only
+     * available if the queue is enabled. This method will throw a RuntimeException if the queue is not enabled.
+     *
+     * @return the name of the response queue
+     * @throws RuntimeException if the response queue is disabled
+     */
+    @Nonnull
+    String getName();
+
+    /**
+     * Returns the response customization object that this response queue object is associated with.
+     *
+     * @return the response customization object that this response queue object is associated with
+     */
+    @Nonnull
+    Response getResponse();
+
+    /**
+     * Returns true if the response queue is enabled.
+     *
+     * @return true if the response queue is enabled
+     */
+    boolean isEnabled();
+
+    /**
+     * Resets the response queue back to its original state, undoing any changes made to it using the {@link #disable() disable()} or
+     * {@link #set(String) set()} methods.
+     */
+    void reset();
+
+    /**
+     * Sets the response queue. If the specified response queue name is non-null then the queue will be enabled and the response queue
+     * name will be set. If the specified name is null then the response queue will be disabled. In this case the method is equivalent to
+     * calling the {@link #disable() disable()} method.
+     *
+     * @param name the name of the response queue, or {@code null} to disable the queue
+     */
+    void set(String name);
+}

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/impl/ResponseImpl.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/impl/ResponseImpl.java
@@ -23,8 +23,9 @@ import javax.annotation.Nonnull;
 public final class ResponseImpl extends DocumentWorkerObjectImpl implements Response
 {
     private final AbstractTask task;
-    private String queueNameOverride;
     private final ResponseCustomDataImpl customData;
+    private final ResponseQueueImpl failureQueue;
+    private final ResponseQueueImpl successQueue;
 
     public ResponseImpl(
         final ApplicationImpl application,
@@ -33,20 +34,9 @@ public final class ResponseImpl extends DocumentWorkerObjectImpl implements Resp
     {
         super(application);
         this.task = task;
-        this.queueNameOverride = null;
         this.customData = new ResponseCustomDataImpl(application, this);
-    }
-
-    @Override
-    public String getQueueNameOverride()
-    {
-        return queueNameOverride;
-    }
-
-    @Override
-    public void setQueueNameOverride(final String queueName)
-    {
-        this.queueNameOverride = queueName;
+        this.failureQueue = new ResponseQueueImpl(application, this, application.getFailureQueue());
+        this.successQueue = new ResponseQueueImpl(application, this, application.getSuccessQueue());
     }
 
     @Nonnull
@@ -58,8 +48,27 @@ public final class ResponseImpl extends DocumentWorkerObjectImpl implements Resp
 
     @Nonnull
     @Override
+    public ResponseQueueImpl getFailureQueue()
+    {
+        return failureQueue;
+    }
+
+    @Nonnull
+    @Override
+    public ResponseQueueImpl getSuccessQueue()
+    {
+        return successQueue;
+    }
+
+    @Nonnull
+    @Override
     public Task getTask()
     {
         return task;
+    }
+
+    public String getOutputQueue(final boolean hasFailures)
+    {
+        return (hasFailures ? failureQueue : successQueue).getQueueName();
     }
 }

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/impl/ResponseQueueImpl.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/impl/ResponseQueueImpl.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2015-2017 EntIT Software LLC, a Micro Focus company.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hpe.caf.worker.document.impl;
+
+import com.hpe.caf.worker.document.model.ResponseQueue;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+
+public final class ResponseQueueImpl extends DocumentWorkerObjectImpl implements ResponseQueue
+{
+    private final ResponseImpl response;
+    private final State originalState;
+    private State currentState;
+
+    public ResponseQueueImpl(final ApplicationImpl application, final ResponseImpl response, final String queueName)
+    {
+        super(application);
+        this.response = response;
+        this.originalState = createState(queueName);
+        this.currentState = originalState;
+    }
+
+    @Override
+    public void disable()
+    {
+        this.currentState = DisabledState.INSTANCE;
+    }
+
+    @Nonnull
+    @Override
+    public String getName()
+    {
+        return currentState.getName();
+    }
+
+    @Nonnull
+    @Override
+    public ResponseImpl getResponse()
+    {
+        return response;
+    }
+
+    @Override
+    public boolean isEnabled()
+    {
+        return currentState.isEnabled();
+    }
+
+    @Override
+    public void reset()
+    {
+        this.currentState = originalState;
+    }
+
+    @Override
+    public void set(final String name)
+    {
+        this.currentState = createState(name);
+    }
+
+    public String getQueueName()
+    {
+        return currentState.getQueueName();
+    }
+
+    private static State createState(final String name)
+    {
+        return (name == null)
+            ? DisabledState.INSTANCE
+            : new EnabledState(name);
+    }
+
+    private interface State
+    {
+        @Nonnull
+        String getName();
+
+        String getQueueName();
+
+        boolean isEnabled();
+    }
+
+    private enum DisabledState implements State
+    {
+        INSTANCE;
+
+        @Nonnull
+        @Override
+        public String getName()
+        {
+            throw new RuntimeException("The response queue is not enabled.");
+        }
+
+        @Override
+        public String getQueueName()
+        {
+            return null;
+        }
+
+        @Override
+        public boolean isEnabled()
+        {
+            return false;
+        }
+    }
+
+    private static final class EnabledState implements State
+    {
+        private final String name;
+
+        public EnabledState(final String name)
+        {
+            this.name = Objects.requireNonNull(name);
+        }
+
+        @Nonnull
+        @Override
+        public String getName()
+        {
+            return name;
+        }
+
+        @Nonnull
+        @Override
+        public String getQueueName()
+        {
+            return name;
+        }
+
+        @Override
+        public boolean isEnabled()
+        {
+            return true;
+        }
+    }
+}

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
@@ -159,14 +159,6 @@ public final class DocumentTask extends AbstractTask
 
     private String getOutputQueue(final List<DocumentWorkerChange> changes)
     {
-        final String queueNameOverride = response.getQueueNameOverride();
-
-        if (queueNameOverride == null) {
-            return ChangeLogFunctions.hasFailures(changes)
-                ? application.getFailureQueue()
-                : application.getSuccessQueue();
-        } else {
-            return queueNameOverride;
-        }
+        return response.getOutputQueue(ChangeLogFunctions.hasFailures(changes));
     }
 }

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/FieldEnrichmentTask.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/FieldEnrichmentTask.java
@@ -25,6 +25,7 @@ import com.hpe.caf.worker.document.DocumentWorkerTask;
 import com.hpe.caf.worker.document.impl.ApplicationImpl;
 import com.hpe.caf.worker.document.impl.ScriptImpl;
 import com.hpe.caf.worker.document.output.DocumentWorkerResultBuilder;
+import com.hpe.caf.worker.document.util.ListFunctions;
 import com.hpe.caf.worker.document.views.ReadOnlyDocument;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -168,8 +169,6 @@ public final class FieldEnrichmentTask extends AbstractTask
 
     private String getOutputQueue(final List<DocumentWorkerFailure> failures)
     {
-        return (failures == null || failures.isEmpty())
-            ? application.getSuccessQueue()
-            : application.getFailureQueue();
+        return response.getOutputQueue(!ListFunctions.isNullOrEmpty(failures));
     }
 }


### PR DESCRIPTION
These changes should:
- allow there to be no response to a document if required (effectively discarding it)
- allow a different queue to be used for failure messages if required