### PR TITLE
SCMOD-4877: Support alternate failure behavior

### DIFF
--- a/worker-document-archetype/src/main/resources/archetype-resources/__rootArtifactId__-container/src/main/config/cfg~caf~worker~DocumentWorkerConfiguration.js
+++ b/worker-document-archetype/src/main/resources/archetype-resources/__rootArtifactId__-container/src/main/config/cfg~caf~worker~DocumentWorkerConfiguration.js
@@ -28,7 +28,7 @@
         fieldEnrichmentTasksAccepted: undefined,
         processSubdocumentsSeparately: undefined
     },
-    enableExceptionOnFailure:getenv("CAF_WORKER_ENABLE_EXCEPTION_ONFAILURE") ||false,
+    enableExceptionOnFailure: getenv("CAF_WORKER_ENABLE_EXCEPTION_ONFAILURE") || false,
     scriptCaching: {
         staticScriptCache: {
             maximumSize: getenv("CAF_WORKER_STATIC_SCRIPT_CACHE_SIZE") || undefined,

--- a/worker-document-archetype/src/main/resources/archetype-resources/__rootArtifactId__-container/src/main/config/cfg~caf~worker~DocumentWorkerConfiguration.js
+++ b/worker-document-archetype/src/main/resources/archetype-resources/__rootArtifactId__-container/src/main/config/cfg~caf~worker~DocumentWorkerConfiguration.js
@@ -28,6 +28,7 @@
         fieldEnrichmentTasksAccepted: undefined,
         processSubdocumentsSeparately: undefined
     },
+    enableExceptionOnFailure:getenv("CAF_WORKER_ENABLE_EXCEPTION_ONFAILURE") ||false,
     scriptCaching: {
         staticScriptCache: {
             maximumSize: getenv("CAF_WORKER_STATIC_SCRIPT_CACHE_SIZE") || undefined,

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/changelog/ChangeLogFunctions.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/changelog/ChangeLogFunctions.java
@@ -51,7 +51,6 @@ public final class ChangeLogFunctions
         for (final DocumentWorkerChange change : changes) {
             if (change.addFailure != null) {
                 hasFailures = true;
-                hasFailures = true;
             }
 
             if (change.setFailures != null) {

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/changelog/ChangeLogFunctions.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/changelog/ChangeLogFunctions.java
@@ -15,7 +15,6 @@
  */
 package com.hpe.caf.worker.document.changelog;
 
-import com.google.common.base.Joiner;
 import com.hpe.caf.worker.document.DocumentWorkerChange;
 import com.hpe.caf.worker.document.DocumentWorkerDocument;
 import com.hpe.caf.worker.document.DocumentWorkerFailure;
@@ -26,16 +25,6 @@ import java.util.List;
  */
 public final class ChangeLogFunctions
 {
-    private static String failureMsg;
-
-    private static String getFailureMsgs() {
-        return failureMsg;
-    }
-
-    private static void setFailureMsgs(String failureMsgs) {
-        ChangeLogFunctions.failureMsg = Joiner.on(",").skipNulls().join(ChangeLogFunctions.failureMsg,failureMsgs);
-    }
-
     /**
      * Overrides the default constructor to ensure that no instances of this class are created.
      */
@@ -61,6 +50,7 @@ public final class ChangeLogFunctions
 
         for (final DocumentWorkerChange change : changes) {
             if (change.addFailure != null) {
+                hasFailures = true;
                 hasFailures = true;
             }
 
@@ -101,46 +91,5 @@ public final class ChangeLogFunctions
 
         return subdocuments != null
             && subdocuments.stream().anyMatch(ChangeLogFunctions::hasFailures);
-    }
-
-    public static String getAllFailureMsgs(final List<DocumentWorkerChange> changes)
-    {
-        if(changes!=null){
-            for (final DocumentWorkerChange change : changes) {
-                if (change.addFailure != null) {
-                    setFailureMsgs(change.addFailure.failureMessage);
-                }
-                if (change.setFailures != null) {
-                    change.setFailures.stream().forEach(documentWorkerFailure -> setFailureMsgs(documentWorkerFailure
-                            .failureMessage));
-                }
-                if(change.addSubdocument!=null){
-                    getAllFailureMsgs(change.addSubdocument);
-                }
-                if(change.insertSubdocument!=null){
-                    getAllFailureMsgs(change.insertSubdocument.subdocument);
-                }
-                if(change.updateSubdocument!=null){
-                    getAllFailureMsgs(change.updateSubdocument.changes);
-                }
-            }
-        }
-        return getFailureMsgs();
-    }
-    private static void getAllFailureMsgs (final DocumentWorkerDocument document){
-        if (document!=null){
-            // Check if it has any failures
-            final List<DocumentWorkerFailure> failures = document.failures;
-
-            if (failures != null && !failures.isEmpty()) {
-                failures.stream().forEach(documentWorkerFailure -> setFailureMsgs(documentWorkerFailure.failureMessage));
-            }
-
-            // Recursively check its subdocuments for failures
-            final List<DocumentWorkerDocument> subdocuments = document.subdocuments;
-            if(subdocuments!=null){
-                subdocuments.stream().forEach(ChangeLogFunctions::getAllFailureMsgs);
-            }
-        }
     }
 }

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/changelog/ChangeLogFunctions.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/changelog/ChangeLogFunctions.java
@@ -15,6 +15,7 @@
  */
 package com.hpe.caf.worker.document.changelog;
 
+import com.google.common.base.Joiner;
 import com.hpe.caf.worker.document.DocumentWorkerChange;
 import com.hpe.caf.worker.document.DocumentWorkerDocument;
 import com.hpe.caf.worker.document.DocumentWorkerFailure;
@@ -25,6 +26,16 @@ import java.util.List;
  */
 public final class ChangeLogFunctions
 {
+    private static String failureMsg;
+
+    private static String getFailureMsgs() {
+        return failureMsg;
+    }
+
+    private static void setFailureMsgs(String failureMsgs) {
+        ChangeLogFunctions.failureMsg = Joiner.on(",").skipNulls().join(ChangeLogFunctions.failureMsg,failureMsgs);
+    }
+
     /**
      * Overrides the default constructor to ensure that no instances of this class are created.
      */
@@ -90,5 +101,46 @@ public final class ChangeLogFunctions
 
         return subdocuments != null
             && subdocuments.stream().anyMatch(ChangeLogFunctions::hasFailures);
+    }
+
+    public static String getAllFailureMsgs(final List<DocumentWorkerChange> changes)
+    {
+        if(changes!=null){
+            for (final DocumentWorkerChange change : changes) {
+                if (change.addFailure != null) {
+                    setFailureMsgs(change.addFailure.failureMessage);
+                }
+                if (change.setFailures != null) {
+                    change.setFailures.stream().forEach(documentWorkerFailure -> setFailureMsgs(documentWorkerFailure
+                            .failureMessage));
+                }
+                if(change.addSubdocument!=null){
+                    getAllFailureMsgs(change.addSubdocument);
+                }
+                if(change.insertSubdocument!=null){
+                    getAllFailureMsgs(change.insertSubdocument.subdocument);
+                }
+                if(change.updateSubdocument!=null){
+                    getAllFailureMsgs(change.updateSubdocument.changes);
+                }
+            }
+        }
+        return getFailureMsgs();
+    }
+    private static void getAllFailureMsgs (final DocumentWorkerDocument document){
+        if (document!=null){
+            // Check if it has any failures
+            final List<DocumentWorkerFailure> failures = document.failures;
+
+            if (failures != null && !failures.isEmpty()) {
+                failures.stream().forEach(documentWorkerFailure -> setFailureMsgs(documentWorkerFailure.failureMessage));
+            }
+
+            // Recursively check its subdocuments for failures
+            final List<DocumentWorkerDocument> subdocuments = document.subdocuments;
+            if(subdocuments!=null){
+                subdocuments.stream().forEach(ChangeLogFunctions::getAllFailureMsgs);
+            }
+        }
     }
 }

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/config/DocumentWorkerConfiguration.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/config/DocumentWorkerConfiguration.java
@@ -58,6 +58,11 @@ public class DocumentWorkerConfiguration extends WorkerConfiguration
      */
     private ScriptCachingConfiguration scriptCaching;
 
+    /**
+     * Enable returning Exception on failure
+     */
+    private boolean enableExceptionOnFailure;
+
     public String getOutputQueue()
     {
         return outputQueue;
@@ -126,5 +131,13 @@ public class DocumentWorkerConfiguration extends WorkerConfiguration
     public void setScriptCaching(final ScriptCachingConfiguration scriptCaching)
     {
         this.scriptCaching = scriptCaching;
+    }
+
+    public boolean getEnableExceptionOnFailure() {
+        return enableExceptionOnFailure;
+    }
+
+    public void setEnableExceptionOnFailure(boolean enableExceptionOnFailure) {
+        this.enableExceptionOnFailure = enableExceptionOnFailure;
     }
 }

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
@@ -121,7 +121,7 @@ public final class DocumentTask extends AbstractTask
 
         boolean changeHasFailures = ChangeLogFunctions.hasFailures(changes);
         // Select the output queue
-        final String outputQueue = getOutputQueue(changeHasFailures);
+        final String outputQueue = response.getOutputQueue(changeHasFailures);
 
         // Serialise the result object
         final byte[] data = application.serialiseResult(documentWorkerResult);
@@ -176,10 +176,5 @@ public final class DocumentTask extends AbstractTask
         final String changeLogEntryName = config.getWorkerName() + ":" + config.getWorkerVersion();
 
         return changeLogEntryName;
-    }
-
-    private String getOutputQueue(final boolean changeHasFailures)
-    {
-        return response.getOutputQueue(changeHasFailures);
     }
 }

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
@@ -117,8 +117,9 @@ public final class DocumentTask extends AbstractTask
         documentWorkerResult.customData = MapFunctions.emptyToNull(response.getCustomData().asMap());
         documentWorkerResult.scripts = ListFunctions.emptyToNull(installedScripts);
 
+        boolean changeHasFailures = ChangeLogFunctions.hasFailures(changes);
         // Select the output queue
-        final String outputQueue = getOutputQueue(changes);
+        final String outputQueue = getOutputQueue(changeHasFailures);
 
         // Serialise the result object
         final byte[] data = application.serialiseResult(documentWorkerResult);
@@ -127,9 +128,9 @@ public final class DocumentTask extends AbstractTask
         final int resultMessageVersion = (documentWorkerResult.scripts == null) ? 1 : 2;
 
         //get the setting enable exception on failure
-        final Boolean enableExceptionOnFailure = application.getConfiguration().getEnableExceptionOnFailure();
-        if(enableExceptionOnFailure==true) {
-            if(ChangeLogFunctions.hasFailures(changes)){
+        final boolean enableExceptionOnFailure = application.getConfiguration().getEnableExceptionOnFailure();
+        if(enableExceptionOnFailure) {
+            if(changeHasFailures ){
                 // Create the WorkerResponse object with Error
                 return new WorkerResponse(outputQueue,
                         TaskStatus.RESULT_EXCEPTION,
@@ -171,8 +172,8 @@ public final class DocumentTask extends AbstractTask
         return changeLogEntryName;
     }
 
-    private String getOutputQueue(final List<DocumentWorkerChange> changes)
+    private String getOutputQueue(final boolean changeHasFailures)
     {
-        return response.getOutputQueue(ChangeLogFunctions.hasFailures(changes));
+        return response.getOutputQueue(changeHasFailures);
     }
 }

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
@@ -35,13 +35,12 @@ import com.hpe.caf.worker.document.util.DocumentFunctions;
 import com.hpe.caf.worker.document.util.ListFunctions;
 import com.hpe.caf.worker.document.util.MapFunctions;
 import com.hpe.caf.worker.document.views.ReadOnlyDocument;
-
-import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 
 public final class DocumentTask extends AbstractTask
 {
@@ -150,11 +149,11 @@ public final class DocumentTask extends AbstractTask
 
         // Create the WorkerResponse object
         return new WorkerResponse(outputQueue,
-                TaskStatus.RESULT_SUCCESS,
-                data,
-                DocumentWorkerConstants.DOCUMENT_TASK_NAME,
-                resultMessageVersion,
-                null);
+                                  TaskStatus.RESULT_SUCCESS,
+                                  data,
+                                  DocumentWorkerConstants.DOCUMENT_TASK_NAME,
+                                  resultMessageVersion,
+                                  null);
     }
 
     @Nonnull

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
@@ -132,9 +132,10 @@ public final class DocumentTask extends AbstractTask
         if(enableExceptionOnFailure) {
             if(changeHasFailures ){
                 // Create the WorkerResponse object with Error
+                final byte[] dataErr = ChangeLogFunctions.getAllFailureMsgs(changes).getBytes();
                 return new WorkerResponse(outputQueue,
                         TaskStatus.RESULT_EXCEPTION,
-                        data,
+                        dataErr,
                         DocumentWorkerConstants.DOCUMENT_TASK_NAME,
                         resultMessageVersion,
                         null);

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
@@ -137,7 +137,7 @@ public final class DocumentTask extends AbstractTask
                 final String failures = DocumentFunctions.documentNodes(document)
                         .flatMap(d->d.getFailures().stream()  )
                         .map(f->f.getFailureId() + ": " + f.getFailureMessage())
-                        .collect(Collectors.joining(", "));
+                        .collect(Collectors.joining("\n"));
 
                 return new WorkerResponse(outputQueue,
                         TaskStatus.RESULT_EXCEPTION,

--- a/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/tasks/DocumentTask.java
@@ -126,13 +126,27 @@ public final class DocumentTask extends AbstractTask
         // If the response message includes any scripts then it is in the v2 message format
         final int resultMessageVersion = (documentWorkerResult.scripts == null) ? 1 : 2;
 
+        //get the setting enable exception on failure
+        final Boolean enableExceptionOnFailure = application.getConfiguration().getEnableExceptionOnFailure();
+        if(enableExceptionOnFailure==true) {
+            if(ChangeLogFunctions.hasFailures(changes)){
+                // Create the WorkerResponse object with Error
+                return new WorkerResponse(outputQueue,
+                        TaskStatus.RESULT_EXCEPTION,
+                        data,
+                        DocumentWorkerConstants.DOCUMENT_TASK_NAME,
+                        resultMessageVersion,
+                        null);
+            }
+        }
+
         // Create the WorkerResponse object
         return new WorkerResponse(outputQueue,
-                                  TaskStatus.RESULT_SUCCESS,
-                                  data,
-                                  DocumentWorkerConstants.DOCUMENT_TASK_NAME,
-                                  resultMessageVersion,
-                                  null);
+                TaskStatus.RESULT_SUCCESS,
+                data,
+                DocumentWorkerConstants.DOCUMENT_TASK_NAME,
+                resultMessageVersion,
+                null);
     }
 
     @Nonnull


### PR DESCRIPTION
https://autjira.microfocus.com/browse/SCMOD-4877

If this is set for a worker and if there are failures, an `RESULT_EXCEPTION` response will be sent instead of `RESULT_SUCCESS`.