### PR TITLE
SCMOD-6287: Override isStringValue() in ReferenceFieldValue

### DIFF
--- a/worker-document/src/main/java/com/hpe/caf/worker/document/fieldvalues/ReferenceFieldValue.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/fieldvalues/ReferenceFieldValue.java
@@ -53,6 +53,12 @@ public final class ReferenceFieldValue extends AbstractFieldValue
         return true;
     }
 
+    @Override
+    public boolean isStringValue()
+    {
+        return false;
+    }
+
     @Nonnull
     @Override
     public InputStream openInputStream() throws IOException


### PR DESCRIPTION
[`AbstractFieldValue#isStringValue`](https://github.com/CAFDataProcessing/worker-document/blob/50e6d39c14776fa07a57761ef9518c835c65e315/worker-document/src/main/java/com/hpe/caf/worker/document/fieldvalues/AbstractFieldValue.java#L90) is not overridden in `ReferenceFieldValue` what is throwing [RuntimeException](https://github.com/CAFDataProcessing/worker-document/blob/50e6d39c14776fa07a57761ef9518c835c65e315/worker-document/src/main/java/com/hpe/caf/worker/document/fieldvalues/ReferenceFieldValue.java#L45) when enclosing `getValue()` is called from [`AbstractFieldValue#isStringValue`](https://github.com/CAFDataProcessing/worker-document/blob/50e6d39c14776fa07a57761ef9518c835c65e315/worker-document/src/main/java/com/hpe/caf/worker/document/fieldvalues/AbstractFieldValue.java#L92)

Opposite of that [NonReferenceFieldValue#isReference](https://github.com/CAFDataProcessing/worker-document/blob/50e6d39c14776fa07a57761ef9518c835c65e315/worker-document/src/main/java/com/hpe/caf/worker/document/fieldvalues/NonReferenceFieldValue.java#L39) is overridden es expected.

Build run locally is successful.