### PR TITLE
SCMOD-6287: Fix test Matcher to allow >1 type of values on field

### DIFF
--- a/worker-document-testing-unit/src/main/java/com/hpe/caf/worker/document/testing/hamcrest/DocumentMatchers.java
+++ b/worker-document-testing-unit/src/main/java/com/hpe/caf/worker/document/testing/hamcrest/DocumentMatchers.java
@@ -74,9 +74,9 @@ public final class DocumentMatchers
      * @param fieldValueMatcher Field value matcher
      * @return Matcher
      */
-    public static IsContainingStringFieldValue containsReference(final String fieldName, final Matcher<String> fieldValueMatcher)
+    public static IsContainingReferenceFieldValue containsReference(final String fieldName, final Matcher<String> fieldValueMatcher)
     {
-        return new IsContainingStringFieldValue(fieldName, fieldValueMatcher, DocumentWorkerFieldEncoding.storage_ref);
+        return new IsContainingReferenceFieldValue(fieldName, fieldValueMatcher, DocumentWorkerFieldEncoding.storage_ref);
     }
 
     /**
@@ -86,7 +86,7 @@ public final class DocumentMatchers
      * @param fieldValue Field value to match
      * @return Matcher
      */
-    public static IsContainingStringFieldValue containsReference(final String fieldName, final String fieldValue)
+    public static IsContainingReferenceFieldValue containsReference(final String fieldName, final String fieldValue)
     {
         return containsReference(fieldName, IsEqual.equalTo(fieldValue));
     }

--- a/worker-document-testing-unit/src/main/java/com/hpe/caf/worker/document/testing/hamcrest/IsContainingByteValue.java
+++ b/worker-document-testing-unit/src/main/java/com/hpe/caf/worker/document/testing/hamcrest/IsContainingByteValue.java
@@ -42,7 +42,7 @@ public class IsContainingByteValue extends IsDocumentContainingFieldValue<byte[]
     }
 
     @Override
-    protected byte[] getFieldValue(final FieldValue fieldValue, final DocumentWorkerFieldEncoding encoding)
+    protected byte[] getFieldValue(final FieldValue fieldValue)
     {
         return fieldValue.getValue();
     }

--- a/worker-document-testing-unit/src/main/java/com/hpe/caf/worker/document/testing/hamcrest/IsContainingFieldValue.java
+++ b/worker-document-testing-unit/src/main/java/com/hpe/caf/worker/document/testing/hamcrest/IsContainingFieldValue.java
@@ -16,15 +16,15 @@
 package com.hpe.caf.worker.document.testing.hamcrest;
 
 import com.hpe.caf.worker.document.DocumentWorkerFieldEncoding;
-import com.hpe.caf.worker.document.model.FieldValue;
+import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
 /**
- * Document string field value matcher.
+ * Document field value matcher.
  */
-public class IsContainingStringFieldValue extends IsContainingFieldValue<String>
+public abstract class IsContainingFieldValue<T> extends IsDocumentContainingFieldValue<String>
 {
-    public IsContainingStringFieldValue(
+    public IsContainingFieldValue(
         final String fieldName,
         final Matcher<String> fieldValueMatcher,
         final DocumentWorkerFieldEncoding encoding
@@ -34,8 +34,8 @@ public class IsContainingStringFieldValue extends IsContainingFieldValue<String>
     }
 
     @Override
-    protected String getFieldValue(final FieldValue fieldValue)
+    protected void describeActual(final String fieldValue, final Description description)
     {
-        return fieldValue.getStringValue();
+        description.appendText(fieldValue);
     }
 }

--- a/worker-document-testing-unit/src/main/java/com/hpe/caf/worker/document/testing/hamcrest/IsContainingReferenceFieldValue.java
+++ b/worker-document-testing-unit/src/main/java/com/hpe/caf/worker/document/testing/hamcrest/IsContainingReferenceFieldValue.java
@@ -20,11 +20,11 @@ import com.hpe.caf.worker.document.model.FieldValue;
 import org.hamcrest.Matcher;
 
 /**
- * Document string field value matcher.
+ * Document reference field value matcher.
  */
-public class IsContainingStringFieldValue extends IsContainingFieldValue<String>
+public class IsContainingReferenceFieldValue extends IsContainingFieldValue<String>
 {
-    public IsContainingStringFieldValue(
+    public IsContainingReferenceFieldValue(
         final String fieldName,
         final Matcher<String> fieldValueMatcher,
         final DocumentWorkerFieldEncoding encoding
@@ -36,6 +36,6 @@ public class IsContainingStringFieldValue extends IsContainingFieldValue<String>
     @Override
     protected String getFieldValue(final FieldValue fieldValue)
     {
-        return fieldValue.getStringValue();
+        return fieldValue.getReference();
     }
 }


### PR DESCRIPTION
[IsDocumentContainingFieldValue#matchesSafely](https://github.com/CAFDataProcessing/worker-document/blob/ce63263756dde4772d81822b6a25b0926a0b3ae6/worker-document-testing-unit/src/main/java/com/hpe/caf/worker/document/testing/hamcrest/IsDocumentContainingFieldValue.java#L50) expected all field values being of one type, what resulted in `RuntimeException`.

Fixed to not use instance of `IsContainingStringFieldValue` to represent logic of _IsContainingReferenceFieldValue_, what is maximally confusing during debugging.

Build is successful locally.