### PR TITLE
D627175: Eviction added to cache builder in JavaScriptEngineLazy()

### DIFF
--- a/worker-document/src/main/java/com/hpe/caf/worker/document/scripting/JavaScriptEngineLazy.java
+++ b/worker-document/src/main/java/com/hpe/caf/worker/document/scripting/JavaScriptEngineLazy.java
@@ -31,7 +31,7 @@ public final class JavaScriptEngineLazy implements ObjectCodeProvider
 
     public JavaScriptEngineLazy()
     {
-        this.scriptEngine = CacheBuilder.newBuilder().concurrencyLevel(1).build(CacheLoader.from(JavaScriptEngineLazy::buildEngine));
+        this.scriptEngine = CacheBuilder.newBuilder().maximumSize(1).concurrencyLevel(1).build(CacheLoader.from(JavaScriptEngineLazy::buildEngine));
     }
 
     @Nonnull


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=627175