### PR TITLE
US656030: Create schema validator once

### DIFF
--- a/release-notes-5.3.0.md
+++ b/release-notes-5.3.0.md
@@ -5,4 +5,7 @@ ${version-number}
 
 #### New Features
 
+#### Bug Fixes
+- US656030: Fixed a concurrency issue in the DocumentValidator where ClassCastException was being thrown when creating a com.worldturner.medeia.schema.validation.SchemaValidator.
+
 #### Known Issues


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=656030

Tested the document validator concurrency issue here: https://github.houston.softwaregrp.net/caf/document-validator-tests
ClassCastException seen here in build 2: https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~document-validator-tests~main~CI/2/console
Test with updated document validator in build 5: https://jenkins.swinfra.net/job/SEPG/job/caf/job/caf~document-validator-tests~main~CI/5/console