### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/worker-document-framework/pom.xml
+++ b/worker-document-framework/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-document-framework</artifactId>
+    <name>worker-document-framework</name>
     <packaging>pom</packaging>
 
     <parent>

--- a/worker-document-interface/pom.xml
+++ b/worker-document-interface/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-document-interface</artifactId>
+    <name>worker-document-interface</name>
 
     <parent>
         <groupId>com.github.cafdataprocessing.workers.document</groupId>

--- a/worker-document-schema/pom.xml
+++ b/worker-document-schema/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-document-schema</artifactId>
+    <name>worker-document-schema</name>
 
     <parent>
         <groupId>com.github.cafdataprocessing.workers.document</groupId>

--- a/worker-document-shared/pom.xml
+++ b/worker-document-shared/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-document-shared</artifactId>
+    <name>worker-document-shared</name>
 
     <parent>
         <groupId>com.github.cafdataprocessing.workers.document</groupId>

--- a/worker-document-testing-unit/pom.xml
+++ b/worker-document-testing-unit/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-document-testing-unit</artifactId>
+    <name>worker-document-testing-unit</name>
 
     <parent>
         <artifactId>worker-document-aggregator</artifactId>

--- a/worker-document-testing/pom.xml
+++ b/worker-document-testing/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-document-testing</artifactId>
+    <name>worker-document-testing</name>
 
     <parent>
         <groupId>com.github.cafdataprocessing.workers.document</groupId>

--- a/worker-document-utility/pom.xml
+++ b/worker-document-utility/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-document-utility</artifactId>
+    <name>worker-document-utility</name>
 
     <parent>
         <groupId>com.github.cafdataprocessing.workers.document</groupId>

--- a/worker-document-validator/pom.xml
+++ b/worker-document-validator/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-document-validator</artifactId>
+    <name>worker-document-validator</name>
 
     <parent>
         <groupId>com.github.cafdataprocessing.workers.document</groupId>

--- a/worker-document/pom.xml
+++ b/worker-document/pom.xml
@@ -22,6 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>worker-document</artifactId>
+    <name>worker-document</name>
 
     <parent>
         <groupId>com.github.cafdataprocessing.workers.document</groupId>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210